### PR TITLE
Add edges and edge explorer tabs to app

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -149,18 +149,26 @@ class TreeInfo:
 
     def edges_data(self):
         ts = self.ts
+        left = ts.edges_left
+        right = ts.edges_right
         edges_parent = ts.edges_parent
         edges_child = ts.edges_child
         nodes_time = ts.nodes_time
+        parent_time = nodes_time[edges_parent]
+        child_time = nodes_time[edges_child]
+        branch_length = parent_time - child_time
+        span = right - left
 
         df = pd.DataFrame(
             {
-                "left": ts.edges_left,
-                "right": ts.edges_right,
+                "left": left,
+                "right": right,
                 "parent": edges_parent,
                 "child": edges_child,
-                "parent_time": nodes_time[edges_parent],
-                "child_time": nodes_time[edges_child],
+                "parent_time": parent_time,
+                "child_time": child_time,
+                "branch_length": branch_length,
+                "span": span,
             }
         )
 
@@ -172,6 +180,8 @@ class TreeInfo:
                 "child": "int",
                 "parent_time": "float64",
                 "child_time": "float64",
+                "branch_length": "float64",
+                "span": "float64",
             }
         )
 


### PR DESCRIPTION
Fixes #42.

I added two tabs to the app: 

1. The Edges tab shows all the edges in the edges table as lines with a height based on the parent time. As with the mutations tab, the actual edges data is overlayed onto the datashaded plot when there are fewer than a given threshold of edges visible in the current viewport. I added the branch length and span of edges to the edges dataframe so that they can be displayed when hovering over an edge.

![image](https://github.com/tskit-dev/tsinfer-qc/assets/5416474/b1382e7a-47ac-4bb4-9bb5-ab5354bfc40c)

3. The Edge explorer tab gives you a box to enter a node into. It then displays all the edges with that node as child, with a Tabulator widget below including all the displayed edges. The Tabulator widget works fine on my laptop, but fails to work for the first attempt when I use it on the Genomics England cluster.

![image](https://github.com/tskit-dev/tsinfer-qc/assets/5416474/9c044110-198b-4a8f-b619-fb7bbc61765e)

There are a few miscellaneous changes here too which could be ignored: I removed some import calls which weren't being used anymore, and I moved all the plot settings to the top of the file (they were buried in particular page functions). 