### PR TITLE
changes to mutation panel

### DIFF
--- a/model.py
+++ b/model.py
@@ -343,6 +343,7 @@ class TSModel:
 
         df = pd.DataFrame(
             {
+                "id": np.arange(ts.num_mutations),
                 "position": position,
                 "node": ts.mutations_node,
                 "time": mutations_time,
@@ -353,10 +354,10 @@ class TSModel:
                 "num_parents": counts.num_parents,
             }
         )
-        df.reset_index(inplace=True)
+
         return df.astype(
             {
-                "index": "int",
+                "id": "int",
                 "position": "float64",
                 "node": "int",
                 "time": "float64",

--- a/model.py
+++ b/model.py
@@ -353,9 +353,10 @@ class TSModel:
                 "num_parents": counts.num_parents,
             }
         )
-
+        df.reset_index(inplace=True)
         return df.astype(
             {
+                "index": "int",
                 "position": "float64",
                 "node": "int",
                 "time": "float64",

--- a/pages/mutations.py
+++ b/pages/mutations.py
@@ -41,7 +41,7 @@ def page(tsm):
     points = tsm.mutations_df.hvplot.scatter(
         x="position",
         y="time",
-        hover_cols=["index", "num_parents", "num_descendants", "num_inheritors"],
+        hover_cols=["id", "num_parents", "num_descendants", "num_inheritors"],
     )
     points.opts(
         width=plot_width,
@@ -54,18 +54,19 @@ def page(tsm):
     filtered = points.apply(filter_points, streams=streams)
 
     tooltips = [
-        ("ID", "@index"),
+        ("ID", "@id"),
         ("parents", "@num_parents"),
         ("descendants", "@num_descendants"),
         ("inheritors", "@num_inheritors"),
     ]
     hover = HoverTool(tooltips=tooltips)
     filtered.opts(
-        color="num_descendants",
-        alpha="num_descendants",
+        color="num_inheritors",
+        alpha="num_inheritors",
         colorbar=True,
+        cmap="kgy",
         colorbar_position="left",
-        clabel="descendants",
+        clabel="inheritors",
         tools=[hover],
     )
     time_hist = hv.DynamicMap(

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -103,6 +103,7 @@ class TestMutationDataTable:
         tsm = model.TSModel(ts)
         df = tsm.mutations_df
         assert len(df) == 6
+        nt.assert_array_equal(df.index, list(range(6)))
         nt.assert_array_equal(df.node, list(range(6)))
         nt.assert_array_equal(df.position, list(range(1, 7)))
         nt.assert_array_equal(df.time, [0, 0, 0, 0, 1, 1])
@@ -117,6 +118,7 @@ class TestMutationDataTable:
         tsm = model.TSModel(ts)
         df = tsm.mutations_df
         assert len(df) == 7
+        nt.assert_array_equal(df.index, list(range(7)))
         nt.assert_array_equal(df.node, [0, 1, 2, 3, 4, 5, 5])
         nt.assert_array_equal(df.position, [1, 2, 3, 4, 5, 6, 6])
         nt.assert_array_equal(df.time, [0, 0, 0, 0, 1, 1, 1])

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -103,7 +103,7 @@ class TestMutationDataTable:
         tsm = model.TSModel(ts)
         df = tsm.mutations_df
         assert len(df) == 6
-        nt.assert_array_equal(df.index, list(range(6)))
+        nt.assert_array_equal(df.id, list(range(6)))
         nt.assert_array_equal(df.node, list(range(6)))
         nt.assert_array_equal(df.position, list(range(1, 7)))
         nt.assert_array_equal(df.time, [0, 0, 0, 0, 1, 1])
@@ -118,7 +118,7 @@ class TestMutationDataTable:
         tsm = model.TSModel(ts)
         df = tsm.mutations_df
         assert len(df) == 7
-        nt.assert_array_equal(df.index, list(range(7)))
+        nt.assert_array_equal(df.id, list(range(7)))
         nt.assert_array_equal(df.node, [0, 1, 2, 3, 4, 5, 5])
         nt.assert_array_equal(df.position, [1, 2, 3, 4, 5, 6, 6])
         nt.assert_array_equal(df.time, [0, 0, 0, 0, 1, 1, 1])


### PR DESCRIPTION
partial fix for issue #66
fixes issue #65

- added an index column to mutations df so we can display mutation ID on hover (not sure if this is the right way to do this)
- added test case for above
- coloured mutations by number of inheritors
- changed tooltip information on hover to display mutation ID, number of parents, inheritors and descendants.
