### PR TITLE
Add loading indicator and error handling to pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import logging
 import pathlib
 import sys
+import traceback
 
 import panel as pn
 import tskit
@@ -30,7 +31,17 @@ pages = {
 
 def show(page):
     yield pn.indicators.LoadingSpinner(value=True, width=50, height=50)
-    content = pages[page](tsm)
+    try:
+        content = pages[page](tsm)
+    except Exception as e:
+        error_message = f"An error occurred: {str(e)}"
+        error_traceback = traceback.format_exc().replace("\n", "<br>")
+        error_traceback = f"<pre>{error_traceback}</pre>"
+        error_panel = pn.pane.Markdown(
+            f"## Error\n\n{error_message}\n\n{error_traceback}", style={"color": "red"}
+        )
+        yield error_panel
+        return
     yield content
 
 

--- a/app.py
+++ b/app.py
@@ -29,7 +29,9 @@ pages = {
 
 
 def show(page):
-    return pages[page](tsm)
+    yield pn.indicators.LoadingSpinner(value=True, width=50, height=50)
+    content = pages[page](tsm)
+    yield content
 
 
 starting_page = pn.state.session_args.get("page", [b"Overview"])[0].decode()


### PR DESCRIPTION
Adds a spinner to indicate that the page is being prepared, and display an error with stacktrace if the page code errors.
![Screenshot from 2023-08-29 23-17-16](https://github.com/tskit-dev/tsinfer-qc/assets/8552/5d4b2a6c-567e-414f-b48a-1b1a65d110c7)
