### PR TITLE
Disable bokeh toolbar

### DIFF
--- a/pages/mutations.py
+++ b/pages/mutations.py
@@ -1,44 +1,13 @@
 import holoviews as hv
 import holoviews.operation.datashader as hd
 import hvplot.pandas  # noqa
-import numpy as np
 import panel as pn
 
 import config
 from plot_helpers import filter_points
 from plot_helpers import hover_points
-
-
-def make_hist_on_axis(dimension, points, num_bins=30):
-    """
-    Make histogram function for a specified axis of a scatter plot
-    """
-
-    def compute_hist(x_range, y_range):
-        filtered_points = filter_points(points, x_range, y_range)
-        hist = hv.operation.histogram(
-            filtered_points, dimension=dimension, num_bins=num_bins, normed="height"
-        )
-        return hist
-
-    return compute_hist
-
-
-def make_hist(data, title, bins_range, log_y=True, plot_width=800):
-    """
-    Make histogram from given count data
-    """
-    count, bins = np.histogram(data, bins=bins_range)
-    ylabel = "log(Count)" if log_y else "Count"
-    np.seterr(divide="ignore")
-    if log_y:
-        count = np.log10(count)
-        count[count == -np.inf] = 0
-    histogram = hv.Histogram((count, bins)).opts(
-        title=title, ylabel=ylabel, tools=["hover"]
-    )
-    histogram = histogram.opts(shared_axes=False, width=round(plot_width / 2))
-    return histogram
+from plot_helpers import make_hist
+from plot_helpers import make_hist_on_axis
 
 
 def make_hist_panel(tsm, log_y):
@@ -79,6 +48,7 @@ def page(tsm):
     streams = [range_stream]
 
     filtered = points.apply(filter_points, streams=streams)
+
     time_hist = hv.DynamicMap(
         make_hist_on_axis(dimension="time", points=points, num_bins=10), streams=streams
     )

--- a/pages/trees.py
+++ b/pages/trees.py
@@ -1,111 +1,85 @@
-import functools
-
 import holoviews as hv
 import numpy as np
 import panel as pn
 
-from plot_helpers import make_hist_matplotlib
+import config
+from plot_helpers import make_hist
 
 
 def page(tsm):
-    hv.extension("matplotlib")
+    hv.extension("bokeh")
     df_trees = tsm.trees_df
     bins = min(50, int(np.sqrt(len(df_trees))))
 
-    sites_hist_func = functools.partial(
-        make_hist_matplotlib,
-        df_trees.num_sites,
-        "Sites per tree",
-        num_bins=bins,
-        log_y=True,
-    )
-
-    log_y_checkbox = pn.widgets.Checkbox(name="log y-axis", value=True)
-
-    sites_hist_panel = pn.bind(
-        sites_hist_func,
-        log_y=log_y_checkbox,
-    )
-
     spans = df_trees.right - df_trees.left
 
-    spans_hist_func = functools.partial(
-        make_hist_matplotlib,
-        spans,
-        "Genomic span per tree",
-        num_bins=bins,
-        log_y=True,
-    )
-
-    spans_hist_panel = pn.bind(
-        spans_hist_func,
-        log_y=log_y_checkbox,
-    )
-
-    muts_hist_func = functools.partial(
-        make_hist_matplotlib,
-        df_trees.num_mutations,
-        "Mutations per tree",
-        num_bins=bins,
-        log_y=True,
-    )
-
-    muts_hist_panel = pn.bind(
-        muts_hist_func,
-        log_y=log_y_checkbox,
-    )
-
-    tbl_hist_func = functools.partial(
-        make_hist_matplotlib,
-        df_trees.total_branch_length,
-        "Total branch length per tree",
-        num_bins=bins,
-        log_y=True,
-    )
-
-    tbl_hist_panel = pn.bind(
-        tbl_hist_func,
-        log_y=log_y_checkbox,
-    )
-
-    mean_arity_hist_func = functools.partial(
-        make_hist_matplotlib,
-        df_trees.mean_internal_arity,
-        "Mean arity per tree \n(not yet implemented)",
-        num_bins=bins,
-        log_y=True,
-    )
-
-    mean_arity_hist_panel = pn.bind(
-        mean_arity_hist_func,
-        log_y=log_y_checkbox,
-    )
-
-    max_arity_hist_func = functools.partial(
-        make_hist_matplotlib,
-        df_trees.max_internal_arity,
-        "Max arity per tree",
-        num_bins=bins,
-        log_y=True,
-    )
-
-    max_arity_hist_panel = pn.bind(
-        max_arity_hist_func,
-        log_y=log_y_checkbox,
-    )
+    log_y_checkbox = pn.widgets.Checkbox(name="log y-axis", value=True)
 
     plot_options = pn.Column(
         pn.pane.Markdown("# Plot Options"),
         log_y_checkbox,
     )
 
-    hist_panel = pn.Column(
-        pn.Row(
-            sites_hist_panel,
-            spans_hist_panel,
-            muts_hist_panel,
-        ),
-        pn.Row(tbl_hist_panel, mean_arity_hist_panel, max_arity_hist_panel),
-    )
+    def make_tree_hist_panel(tsm, log_y):
+        sites_hist = make_hist(
+            df_trees.num_sites,
+            "Sites per tree",
+            bins,
+            log_y=log_y,
+            plot_width=config.PLOT_WIDTH,
+        )
+
+        spans_hist = make_hist(
+            spans,
+            "Genomic span per tree",
+            bins,
+            log_y=log_y,
+            plot_width=config.PLOT_WIDTH,
+        )
+
+        muts_hist = make_hist(
+            df_trees.num_mutations,
+            "Mutations per tree",
+            bins,
+            log_y=log_y,
+            plot_width=config.PLOT_WIDTH,
+        )
+
+        tbl_hist = make_hist(
+            df_trees.total_branch_length,
+            "Total branch length per tree",
+            bins,
+            log_y=log_y,
+            plot_width=config.PLOT_WIDTH,
+        )
+
+        mean_arity_hist = make_hist(
+            df_trees.mean_internal_arity,
+            "Mean arity per tree \n(not yet implemented)",
+            bins,
+            log_y=log_y,
+            plot_width=config.PLOT_WIDTH,
+        )
+
+        max_arity_hist = make_hist(
+            df_trees.max_internal_arity,
+            "Max arity per tree",
+            bins,
+            log_y=log_y,
+            plot_width=config.PLOT_WIDTH,
+        )
+        return pn.Column(
+            pn.Row(
+                sites_hist,
+                spans_hist,
+            ),
+            pn.Row(
+                muts_hist,
+                tbl_hist,
+            ),
+            pn.Row(mean_arity_hist, max_arity_hist),
+        )
+
+    hist_panel = pn.bind(make_tree_hist_panel, log_y=log_y_checkbox, tsm=tsm)
 
     return pn.Column(hist_panel, plot_options)

--- a/plot_helpers.py
+++ b/plot_helpers.py
@@ -1,5 +1,6 @@
 import holoviews as hv
 import numpy as np
+import panel as pn
 
 import config
 
@@ -36,3 +37,58 @@ def make_hist_matplotlib(data, title, num_bins, log_y=True, xlim=(None, None)):
         count[count == -np.inf] = 0
 
     return hv.Histogram((count, bins)).opts(title=title, ylabel=ylabel)
+
+
+def make_hist_on_axis(dimension, points, num_bins=30):
+    """
+    Make histogram function for a specified axis of a scatter plot
+    """
+
+    def compute_hist(x_range, y_range):
+        filtered_points = filter_points(points, x_range, y_range)
+        hist = hv.operation.histogram(
+            filtered_points, dimension=dimension, num_bins=num_bins, normed="height"
+        )
+        return hist
+
+    return compute_hist
+
+
+def make_hist(data, title, bins_range, log_y=True, plot_width=800):
+    """
+    Make histogram from given count data
+    """
+    count, bins = np.histogram(data, bins=bins_range)
+    ylabel = "log(Count)" if log_y else "Count"
+    np.seterr(divide="ignore")
+    if log_y:
+        count = np.log10(count)
+        count[count == -np.inf] = 0
+    histogram = hv.Histogram((count, bins)).opts(
+        title=title, ylabel=ylabel, tools=["hover"]
+    )
+    histogram = histogram.opts(
+        shared_axes=False, width=round(plot_width / 2), toolbar=None, default_tools=[]
+    )
+    return histogram
+
+
+def make_hist_panel(tsm, log_y):
+    """
+    Make row of histograms for holoviews panel
+    """
+    overall_site_hist = make_hist(
+        tsm.sites_num_mutations,
+        "Mutations per site",
+        range(29),
+        log_y=log_y,
+        plot_width=config.PLOT_WIDTH,
+    )
+    overall_node_hist = make_hist(
+        tsm.nodes_num_mutations,
+        "Mutations per node",
+        range(10),
+        log_y=log_y,
+        plot_width=config.PLOT_WIDTH,
+    )
+    return pn.Row(overall_site_hist, overall_node_hist)


### PR DESCRIPTION
Fixes issue #69

Changed all histograms to bokeh
Moved hist function to plot_helpers

Will delete the matplotlib plots in the Trees page if we decide to go with bokeh throughout.